### PR TITLE
UMD pattern

### DIFF
--- a/lib/jquery.sizes.js
+++ b/lib/jquery.sizes.js
@@ -6,7 +6,36 @@
  * All rights reserved.
  */
 /*global jQuery*/
-(function ($) {
+
+// https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js
+// Uses CommonJS, AMD or browser globals to create a jQuery plugin.
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node/CommonJS
+    module.exports = function( root, jQuery ) {
+      if ( jQuery === undefined ) {
+        // require('jQuery') returns a factory that requires window to
+        // build a jQuery instance, we normalize how we use modules
+        // that require this pattern but the window provided is a noop
+        // if it's defined (how jquery works)
+        if ( typeof window !== 'undefined' ) {
+          jQuery = require('jquery');
+        }
+        else {
+          jQuery = require('jquery')(root);
+        }
+      }
+      factory(jQuery);
+      return jQuery;
+    };
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
 	'use strict';
 	var num = function (value) {
 			return parseInt(value, 10) || 0;
@@ -73,4 +102,4 @@
 			return this;
 		};
 	});
-}(jQuery));
+}));

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@evidentpoint/jquery-sizes",
+  "name": "jquery-sizes",
   "version": "0.33.0",
   "description": "jQuery extension plugin for CSS properties",
   "main": "lib/jquery.sizes.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery-sizes",
+  "name": "@evidentpoint/jquery-sizes",
   "version": "0.33.0",
   "description": "jQuery extension plugin for CSS properties",
   "main": "lib/jquery.sizes.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jquery-sizes",
   "version": "0.33.0",
   "description": "jQuery extension plugin for CSS properties",
+  "main": "lib/jquery.sizes.js",
   "keywords": [
     "jQuery sizes jsizes"
   ],


### PR DESCRIPTION
This will define the plugin to be compatible as an AMD module or CommonJS module.
It makes it easier to use when you are importing jQuery and this when you are using RequireJS. 
That appears to be the case for issue #6

For more details:
https://github.com/umdjs/umd
https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js

